### PR TITLE
Automate 2-level cache with pub-src-redis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [10, 12, 13]
+        node: [10, 12, 14]
         os:
         - ubuntu-latest
         - macos-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pub-resolve-opts
-![CI](https://github.com/jldec/pub-resolve-opts/workflows/CI/badge.svg)
+[![CI](https://github.com/jldec/pub-resolve-opts/workflows/CI/badge.svg)](https://github.com/jldec/pub-resolve-opts/actions)
 
 config resolver for pub-generator and pub-server
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "pub-resolve-opts",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "pub-config resolver for pub-generator and pub-server",
   "main": "resolve-opts.js",
   "dependencies": {
     "debug": "^4.1.1",
-    "logger-emitter": "^1.0.8",
+    "logger-emitter": "^1.0.9",
     "osenv": "^0.1.5",
-    "pub-util": "^3.1.0",
+    "pub-util": "^3.1.1",
     "resolve": "^1.17.0"
   },
   "devDependencies": {
-    "eslint": "^7.2.0",
+    "eslint": "^7.5.0",
     "pub-pkg-jquery": "^1.12.4",
-    "pub-src-fs": "^2.1.0",
+    "pub-src-fs": "^2.1.1",
     "tape": "^5.0.1",
     "tape-catch": "^1.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub-resolve-opts",
-  "version": "1.7.8",
+  "version": "1.8.0",
   "description": "pub-config resolver for pub-generator and pub-server",
   "main": "resolve-opts.js",
   "dependencies": {
@@ -11,7 +11,7 @@
     "resolve": "^1.17.0"
   },
   "devDependencies": {
-    "eslint": "^7.1.0",
+    "eslint": "^7.2.0",
     "pub-pkg-jquery": "^1.12.4",
     "pub-src-fs": "^2.1.0",
     "tape": "^5.0.1",

--- a/resolve-opts.js
+++ b/resolve-opts.js
@@ -161,6 +161,8 @@ function resolveOpts(opts, builtins) {
   if (opts.editor) {
     var editorPkg = opts['editor-pkg'] || 'pub-pkg-editor';
     opts.pkgs.push(resolvePkg(normalize(editorPkg)));
+    // editorPrefix must not have trailing /, will redirect to path with trailing /
+    opts.editorPrefix = opts.editorPrefix || '/pub';
   }
 
   opts.theme = u.find(opts.pkgs, function(pkg) {


### PR DESCRIPTION
- 2-level cache allows staging of editor changes
- also: default opts.editorPrefix
